### PR TITLE
Smaller docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# Source image
-# FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
-FROM python:3.7
+FROM python:3.7.4-slim
 
-
+RUN apt-get update \
+    && apt-get install git libmagic1 --no-install-recommends -y \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install uvicorn
 
 # Set environment varibles


### PR DESCRIPTION
Let's make our users life easier and lighter. Less downloads, less disk space.

Slim images are often better choice for deployment since they are smaller. They don't come with everything by default but  things missing can be added with apt-get command. In this case we only need git and libmagic.


Before:

```
docker image ls | grep import-export-1_backend
import-export-1_backend    1.13GB
```

After:

```
docker image ls | grep import-export-1_backend
import-export-1_backend    527MB
```