### PR TITLE
Fixed the job status diagram

### DIFF
--- a/app/controller/importer_proxy.py
+++ b/app/controller/importer_proxy.py
@@ -85,7 +85,7 @@ class ImporterProxy:
 
         except Exception as e:
             print(e)
-            return {"error": "Manifest is None"}
+            return None
 
     def handle_thingiverse(self, url, auth_token, job_id):
         imp = ThingiverseImporter(job_id)

--- a/app/controller/importers/dropbox_importer.py
+++ b/app/controller/importers/dropbox_importer.py
@@ -33,23 +33,23 @@ class DropboxImporter(Importer):
         print("Dropbox: Starting process of URL: {}".format(url))
         # Create the manifest instance
 
-        dropbox_handler = dropbox.Dropbox(auth_token)
+        try:
+            dropbox_handler = dropbox.Dropbox(auth_token)
 
-        print(dropbox_handler.users_get_current_account())
+            manifest = Manifest()
 
-        manifest = Manifest()
+            self.process_folder_recursively(manifest, dropbox_handler, url)
+            self.create_folder_structure_sync(self.elements_list)
 
-        self.process_folder_recursively(manifest, dropbox_handler, url)
-        self.create_folder_structure_sync(self.elements_list)
+            self.download_all_files(dropbox_handler, self.elements_list)
 
-        self.download_all_files(dropbox_handler, self.elements_list)
+            # Finally, set the status
+            self.set_status(StatusEnum.importing_successfully.value)
 
-        # Finally, set the status
-        self.set_status(StatusEnum.importing_successfully.value)
-
-        print(self.job_id)
-
-        return manifest
+            return manifest
+        except Exception as e:
+            self.on_import_error_found(e)
+            return None
 
     def process_folder_recursively(self, manifest, dropbox_handler, url):
 

--- a/app/controller/importers/git_importer.py
+++ b/app/controller/importers/git_importer.py
@@ -76,7 +76,8 @@ class GitImporter(Importer):
             return manifest
 
         except Exception as e:
-            self.set_status(StatusEnum.importing_error_data_unreachable.value)
+            # self.set_status(StatusEnum.importing_error_data_unreachable.value)
+            self.on_import_error_found(e)
             print(e)
             return None
 

--- a/app/controller/importers/googledrive_importer.py
+++ b/app/controller/importers/googledrive_importer.py
@@ -56,20 +56,22 @@ class GoogleDriveImporter(Importer):
                 "drive", "v3", credentials=creds, cache_discovery=False
             )
 
+            # Create the manifest instance
+            manifest = Manifest()
+
+            self.process_folder_recursively(manifest, drive_service, url)
+            self.create_folder_structure_sync(self.elements_list)
+
+            self.download_all_files(drive_service, self.elements_list)
+
+            # Finally, set the status
+            self.set_status(StatusEnum.importing_successfully.value)
+            return manifest
+
         except Exception as e:
             print(e)
-
-        # Create the manifest instance
-        manifest = Manifest()
-
-        self.process_folder_recursively(manifest, drive_service, url)
-        self.create_folder_structure_sync(self.elements_list)
-
-        self.download_all_files(drive_service, self.elements_list)
-
-        # Finally, set the status
-        self.set_status(StatusEnum.importing_successfully.value)
-        return manifest
+            self.on_import_error_found(e)
+            return None
 
     def create_folder_structure_sync(self, elements):
 

--- a/app/controller/importers/wikifactory_importer.py
+++ b/app/controller/importers/wikifactory_importer.py
@@ -90,22 +90,28 @@ class WikifactoryImporter(Importer):
     def process_url(self, import_url, import_token):
         print("WIKIFACTORY: Starting process")
 
-        manifest = Manifest()
+        try:
 
-        project_info = self.get_project_details(import_url, import_token)
+            project_info = self.get_project_details(import_url, import_token)
 
-        # INFO: Maybe use the name or other field here?
-        manifest.project_name = project_info["slug"]
+            manifest = Manifest()
+            # INFO: Maybe use the name or other field here?
+            manifest.project_name = project_info["slug"]
 
-        # Download the files
-        self.download_files_from_zip_url(project_info["zip_archive_url"])
+            # Download the files
+            self.download_files_from_zip_url(project_info["zip_archive_url"])
 
-        # Populate the manifest from the directory
-        self.populate_manifest_from_folder_path(manifest, self.path)
+            # Populate the manifest from the directory
+            self.populate_manifest_from_folder_path(manifest, self.path)
 
-        # Finally, set the status
-        self.set_status(StatusEnum.importing_successfully.value)
-        return manifest
+            # Finally, set the status
+            self.set_status(StatusEnum.importing_successfully.value)
+            return manifest
+
+        except Exception as e:
+            print(e)
+            self.on_import_error_found(e)
+            return None
 
     def get_project_details(self, import_url, import_token):
 

--- a/app/model/importer.py
+++ b/app/model/importer.py
@@ -1,5 +1,6 @@
-from app.models import StatusEnum
-from app.models import set_job_status, Session
+from app.models import StatusEnum, Session, JobStatus
+from app.models import set_job_status
+from sqlalchemy.orm.exc import NoResultFound
 
 
 class Importer:
@@ -44,6 +45,37 @@ class Importer:
         # Remove the hook for that status
         if action in self.hooks_for_status[status]:
             self.hooks_for_status[status].remove(action)
+
+    def on_import_error_found(self, exception):
+
+        session = Session()
+
+        # First, check in the db if the job has the login_required status
+
+        try:
+
+            session.query(JobStatus.job_id, JobStatus.status).filter(
+                JobStatus.job_id == self.job_id
+            ).filter(
+                JobStatus.status.in_(
+                    [StatusEnum.importing_error_authorization_required.value]
+                )
+            ).one()
+
+            # At this point, we know that for that job_id, we have the
+            # authorization_required status and the user is retrying the process
+            # Then, we set the status to data_unreachable
+            set_job_status(
+                self.job_id, StatusEnum.importing_error_data_unreachable.value
+            )
+        except NoResultFound as e:
+            print(e)
+            # First time trying to find the auth_required status,
+            # Since we didn't find it, we must create it
+            set_job_status(
+                self.job_id,
+                StatusEnum.importing_error_authorization_required.value,
+            )
 
 
 class NotValidURLForImportException(ValueError):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,12 @@
+from app.models import Session, Job, JobStatus
+
+WIKIFACTORY_TOKEN = "eyJfcGVybWFuZW50Ijp0cnVlLCJ1c2VybmFtZSI6InRlc3R1c2VyMyJ9.YButtw.ksOvNRFeFmq5BHU1JjcS3AiVilg"
+WIKIFACTORY_TEST_PROJECT_URL = "http://frontend:8080/@testuser3/newyork"
+
+
+def pytest_sessionfinish(session, exitstatus):
+    session = Session()
+    session.query(JobStatus).delete()
+    session.query(Job).delete()
+
+    session.commit()

--- a/app/tests/integration_tests/test_job.py
+++ b/app/tests/integration_tests/test_job.py
@@ -1,0 +1,338 @@
+from app.models import add_job_to_db, get_job
+from app.models import Session, Job, JobStatus, StatusEnum
+from app.tests.conftest import WIKIFACTORY_TOKEN, WIKIFACTORY_TEST_PROJECT_URL
+from app.controller.importer_proxy import ImporterProxy
+from app.controller.exporter_proxy import ExporterProxy
+
+import pytest
+import uuid
+
+test_url = "http://testurl.com"
+
+
+def create_job(
+    import_service="git",
+    import_token="",
+    import_url="",
+    export_service="git",
+    export_token="",
+    export_url="",
+):
+
+    job_id = str(uuid.uuid4())
+
+    job = {
+        "import_service": import_service,
+        "import_token": import_token,
+        "import_url": import_url,
+        "export_service": export_service,
+        "export_token": export_token,
+        "export_url": export_url,
+    }
+
+    return (job_id, job)
+
+
+def test_get_job_success():
+
+    (job_id, job) = create_job(import_url=test_url)
+
+    # Add the job to the db directly, not using the add_job_to_db method
+    session = Session()
+    new_job = Job()
+    new_job.job_id = job_id
+    new_job.import_service = job["import_service"]
+    new_job.import_token = job["import_token"]
+    new_job.import_url = job["import_url"]
+    new_job.export_service = job["export_service"]
+    new_job.export_token = job["export_token"]
+    new_job.export_url = job["export_url"]
+
+    new_job.processed_elements = 0
+    new_job.file_elements = 0
+
+    new_status = JobStatus()
+    new_status.job_id = new_job.job_id
+    new_status.status = StatusEnum.pending.value
+
+    session.add(new_job)
+    session.add(new_status)
+    session.commit()
+
+    found_job = get_job(job_id)
+
+    assert found_job is not None
+    assert found_job["job_id"] == job_id
+    assert "job_status" in found_job
+    assert found_job["job_status"] == new_status.status
+    assert "job_progress" in found_job
+    assert found_job["job_progress"] == 0  # because is a newly created one
+
+
+def test_get_job_fail():
+    unexisting_job_id = "00000000-0000-0000-0000-000000000000"
+    found_job = get_job(unexisting_job_id)
+    assert found_job is None
+
+
+def test_add_job_to_db():
+
+    (job_id, job) = create_job(import_url=test_url)
+
+    # Add the job to the db
+    add_job_to_db(
+        job,
+        job_id,
+    )
+
+    # The created job should appear in the db
+    job = get_job(job_id)
+
+    assert job["job_id"] == job_id
+    assert job["job_progress"] == 0  # Newly created
+
+
+def test_import_from_git_to_wikifactory_fail():
+
+    (job_id, job) = create_job(
+        # import_url="https://github.com/CollectiveOpenSourceHardware/LibreSolar_System_Simulation",
+        import_url="https://github.com/rievo/icosphere",
+        import_service="git",
+        export_url=WIKIFACTORY_TEST_PROJECT_URL[
+            ::-1
+        ],  # Using a not valid wikifactory url will cause the process to fail
+        export_service="wikifactory",
+        export_token=WIKIFACTORY_TOKEN,
+    )
+
+    # Add the job to the db
+    add_job_to_db(job, job_id)
+
+    processing_prx = ImporterProxy(job_id)
+    manifest = processing_prx.handle_request(job)
+
+    assert manifest is not None
+
+    export_proxy = ExporterProxy(job_id)
+    result = export_proxy.export_manifest(manifest, job)
+
+    assert result is None
+
+
+@pytest.mark.needs_alpha
+def test_import_from_git_to_wikifactory_success():
+
+    (job_id, job) = create_job(
+        # import_url="https://github.com/CollectiveOpenSourceHardware/LibreSolar_System_Simulation",
+        import_url="https://github.com/rievo/icosphere",
+        import_service="git",
+        export_url=WIKIFACTORY_TEST_PROJECT_URL,
+        export_service="wikifactory",
+        export_token=WIKIFACTORY_TOKEN,
+    )
+
+    # Add the job to the db
+    add_job_to_db(job, job_id)
+
+    # result_manifest = handle_post_export.delay(job, job_id).get()
+
+    processing_prx = ImporterProxy(job_id)
+    manifest = processing_prx.handle_request(job)
+
+    assert manifest is not None
+
+    export_proxy = ExporterProxy(job_id)
+    result = export_proxy.export_manifest(manifest, job)
+
+    assert result is not None
+
+
+def test_job_overall_status_not_completed():
+
+    session = Session()
+
+    (job_id, job) = create_job(
+        import_url="testurl",
+        import_service="googledrive",
+        export_url="testurl",
+        export_service="googledrive",
+        export_token="testtoken",
+    )
+
+    # Add the job to the db
+    add_job_to_db(job, job_id)
+
+    # Add to the db the following statuses
+
+    # importing
+    importing_status = JobStatus()
+    importing_status.job_id = job_id
+    importing_status.status = StatusEnum.importing.value
+    session.add(importing_status)
+
+    # importing_succesfully
+    importing_succesfully_status = JobStatus()
+    importing_succesfully_status.job_id = job_id
+    importing_succesfully_status.status = (
+        StatusEnum.importing_successfully.value
+    )
+    session.add(importing_succesfully_status)
+    session.commit()
+
+    # The created job should appear in the db
+    retrieved_job = get_job(job_id)
+
+    assert retrieved_job["job_id"] == job_id
+
+    # Check the last status
+    assert (
+        retrieved_job["job_status"] == StatusEnum.importing_successfully.value
+    )
+
+    assert retrieved_job["overall_process"] == pytest.approx(3 / 5 * 100)
+
+
+def test_job_overall_status_complete_job():
+
+    session = Session()
+
+    (job_id, job) = create_job(
+        import_url="testurl",
+        import_service="googledrive",
+        export_url="testurl",
+        export_service="googledrive",
+        export_token="testtoken",
+    )
+
+    # Add the job to the db
+    add_job_to_db(job, job_id)
+
+    # Add to the db the following statuses
+
+    # importing
+    importing_status = JobStatus()
+    importing_status.job_id = job_id
+    importing_status.status = StatusEnum.importing.value
+    session.add(importing_status)
+
+    # importing_succesfully
+    importing_succesfully_status = JobStatus()
+    importing_succesfully_status.job_id = job_id
+    importing_succesfully_status.status = (
+        StatusEnum.importing_successfully.value
+    )
+    session.add(importing_succesfully_status)
+
+    # exporting
+    exporting_status = JobStatus()
+    exporting_status.job_id = job_id
+    exporting_status.status = StatusEnum.exporting.value
+    session.add(exporting_status)
+
+    # exporting_succesfully
+    exporting_succesfully_status = JobStatus()
+    exporting_succesfully_status.job_id = job_id
+    exporting_succesfully_status.status = (
+        StatusEnum.exporting_successfully.value
+    )
+    session.add(exporting_succesfully_status)
+
+    session.commit()
+
+    # The created job should appear in the db
+    retrieved_job = get_job(job_id)
+    print(job_id)
+
+    assert retrieved_job["job_id"] == job_id
+
+    # Check the last status
+    assert (
+        retrieved_job["job_status"] == StatusEnum.exporting_successfully.value
+    )
+
+    assert retrieved_job["overall_process"] == pytest.approx(100)
+
+
+def test_export_error_status_change():
+
+    session = Session()
+    # Try to import from git, with a non-valid url
+    # That should first add an "auth_required" status to the db for that job
+    # and then if the user retries the process, a "data_not_reachable" one
+
+    (job_id, job) = create_job(
+        import_url="https://github.com/rievo/icosphere"[
+            ::-1
+        ],  # Unexisting url
+        import_service="git",
+    )  # default export parameters
+
+    # Add the job to the db as well as the "pending" status
+    add_job_to_db(job, job_id)
+
+    # Start the importing process
+    processing_prx = ImporterProxy(job_id)
+
+    manifest = processing_prx.handle_request(job)
+
+    # Since there was an error, the manifest couldn't be generated
+    assert manifest is None
+
+    # Additionally, since this is the first try of importing it,
+    # we should be able to see in the db the auth required status
+    auth_result = (
+        session.query(JobStatus.job_id, JobStatus.status)
+        .filter(JobStatus.job_id == job_id)
+        .filter(
+            JobStatus.status.in_(
+                [StatusEnum.importing_error_authorization_required.value]
+            )
+        )
+        .all()
+    )
+
+    assert len(auth_result) == 1  # The auth required status is in the db
+
+    unreachable_result = (
+        session.query(JobStatus.job_id, JobStatus.status)
+        .filter(JobStatus.job_id == job_id)
+        .filter(
+            JobStatus.status.in_(
+                [StatusEnum.importing_error_data_unreachable.value]
+            )
+        )
+        .all()
+    )
+    assert len(unreachable_result) == 0  # The data unreachable is there
+
+    # If we try to handle the request again:
+    manifest = processing_prx.handle_request(job)
+
+    assert manifest is None  # Manifest not generated again
+
+    # Check if we still have only auth required status
+    auth_result = (
+        session.query(JobStatus.job_id, JobStatus.status)
+        .filter(JobStatus.job_id == job_id)
+        .filter(
+            JobStatus.status.in_(
+                [StatusEnum.importing_error_authorization_required.value]
+            )
+        )
+        .all()
+    )
+
+    assert len(auth_result) == 1  # The auth required status is in the db
+
+    # Finally, test if we have the unreachabler result in the db
+    unreachable_result = (
+        session.query(JobStatus.job_id, JobStatus.status)
+        .filter(JobStatus.job_id == job_id)
+        .filter(
+            JobStatus.status.in_(
+                [StatusEnum.importing_error_data_unreachable.value]
+            )
+        )
+        .all()
+    )
+    assert len(unreachable_result) == 1  # The data unreachable is there


### PR DESCRIPTION
Now, we use the on_import_error_found method to change the status of the jobs. Thus, the first time we encounter an error, the status is set to "auth_required". If later, the job is executed again, and still finds an error, the status of the job will change to "data_unreachable"