### PR TITLE
Fix: set empty description if not set

### DIFF
--- a/app/importers/google_drive.py
+++ b/app/importers/google_drive.py
@@ -156,5 +156,8 @@ class GoogleDriveImporter(BaseImporter):
 
     def populate_project_description(self, manifest_input: ManifestInput) -> None:
         self.root_item.FetchMetadata(fields="description")
-        manifest_input.project_description = self.root_item.get("description")
+        description = self.root_item.get("description")
+        manifest_input.project_description = (
+            description if description is not None else ""
+        )
         crud.manifest.update_or_create(self.db, obj_in=manifest_input)

--- a/app/importers/google_drive.py
+++ b/app/importers/google_drive.py
@@ -156,8 +156,5 @@ class GoogleDriveImporter(BaseImporter):
 
     def populate_project_description(self, manifest_input: ManifestInput) -> None:
         self.root_item.FetchMetadata(fields="description")
-        description = self.root_item.get("description")
-        manifest_input.project_description = (
-            description if description is not None else ""
-        )
+        manifest_input.project_description = self.root_item.get("description", "")
         crud.manifest.update_or_create(self.db, obj_in=manifest_input)


### PR DESCRIPTION
Now, if the "description" field of the folder is not set in google drive, we default to an empty string