### PR TITLE
Fixed process for shared folders with shared subfolders

### DIFF
--- a/app/importers/dropbox.py
+++ b/app/importers/dropbox.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from pathlib import Path
 from re import search
 from typing import Dict, List, Optional
@@ -53,6 +54,8 @@ class DropboxImporter(BaseImporter):
             "entry": FolderMetadata(id="root-folder", name="root-folder"),
             "children": {},
         }
+        self.shared_link = None
+        self.original_url = ""
 
     def process(self) -> None:
 
@@ -84,7 +87,10 @@ class DropboxImporter(BaseImporter):
         self.url_type = url_details["type"]
 
         try:
-            self.build_tree_recursively(self.tree_root["children"], url_details["path"])
+            self.build_tree_recursively(
+                self.tree_root["children"],
+                url_details["path"],
+            )
             self.download_tree_recursively(self.tree_root["children"], job.path)
         except (AuthError, HttpError, BadInputError):
             crud.job.update_status(
@@ -126,28 +132,42 @@ class DropboxImporter(BaseImporter):
 
         entries = []
 
-        if self.url_type == "shared":
+        try:
 
-            # Change the type to id to treat the following folders as ids
-            self.url_type = "id"
+            if self.url_type == "shared":  # First time processing a shared link
 
-            link = dropbox.files.SharedLink(
-                url=folder_path,
-            )
+                # Change the type to id to treat the following folders as ids
+                self.url_type = "id"
+                self.original_url = folder_path
 
-            # When handling a shared_link folder, treat the first iteration different
-            result = self.dropbox_handler.files_list_folder(path="", shared_link=link)
+                link = dropbox.files.SharedLink(
+                    url=folder_path,
+                )
 
-        elif self.url_type == "user_folder" or self.url_type == "id":
-            result = self.dropbox_handler.files_list_folder(path=folder_path)
+                self.shared_link = link
 
-        entries.extend(result.entries)
+                # When handling a shared_link folder, treat the first iteration different
+                result = self.dropbox_handler.files_list_folder(
+                    path="", shared_link=link, include_mounted_folders=True
+                )
 
-        while result.has_more:
-            result = self.dropbox_handler.files_list_folder_continue(result.cursor)
+            elif self.url_type == "id":  # After that, working with the id
+                result = self.dropbox_handler.files_list_folder(
+                    path=folder_path, shared_link=self.shared_link
+                )
+            elif self.url_type == "user_folder":
+                result = self.dropbox_handler.files_list_folder(path=folder_path)
+
             entries.extend(result.entries)
 
-        return entries
+            while result.has_more:
+                result = self.dropbox_handler.files_list_folder_continue(result.cursor)
+                entries.extend(result.entries)
+
+            return entries
+        except ApiError:
+            traceback.print_exc()
+            return []
 
     def build_tree_recursively(self, current_level: Dict, folder_url: str) -> None:
 
@@ -155,14 +175,28 @@ class DropboxImporter(BaseImporter):
 
         for entry in entries:
             name = entry.name
-            current_level[name] = {"entry": entry, "children": {}}
+
+            entry_full_path = os.path.join(folder_url, name)
+
+            current_level[name] = {
+                "entry": entry,
+                "children": {},
+                "path": entry_full_path.replace(self.original_url, ""),
+            }
 
         for node in current_level.values():
             entry = node.get("entry")
+
             if isinstance(entry, dropbox.files.FileMetadata):
                 pass
             elif isinstance(entry, dropbox.files.FolderMetadata):
-                self.build_tree_recursively(node.get("children"), entry.id)
+
+                if self.url_type == "id":
+                    path = node.get("path")
+                    self.build_tree_recursively(node.get("children"), path)
+
+                else:
+                    self.build_tree_recursively(node.get("children"), entry.id)
 
     def download_tree_recursively(
         self, current_level: Dict, accumulated_path: str
@@ -179,8 +213,25 @@ class DropboxImporter(BaseImporter):
             if isinstance(entry, dropbox.files.FolderMetadata):
                 self.download_tree_recursively(node.get("children"), entry_full_path)
             else:
-                self.dropbox_handler.files_download_to_file(
-                    entry_full_path, entry.path_lower
-                )
+
+                if entry.path_lower is None and self.url_type == "id":
+
+                    assert self.shared_link
+
+                    shared_path = entry_full_path.replace(str(self.job_id), "")
+                    (
+                        metadata,
+                        result,
+                    ) = self.dropbox_handler.sharing_get_shared_link_file(
+                        url=self.shared_link.url, path=shared_path
+                    )
+
+                    with open(entry_full_path, "wb") as f:
+                        f.write(result.content)
+
+                else:
+                    self.dropbox_handler.files_download_to_file(
+                        download_path=entry_full_path, path=entry.path_lower
+                    )
                 print("Downloaded file: {}".format(entry.name))
                 crud.job.increment_imported_items(self.db, job_id=self.job_id)

--- a/app/tests/importers/test_dropbox.py
+++ b/app/tests/importers/test_dropbox.py
@@ -224,8 +224,6 @@ def test_dropbox_importer_success(
 @pytest.fixture
 def launch_api_error(monkeypatch: Any, exception: Exception) -> None:
     def mock_api_exception(*args: List, **kwargs: Dict) -> None:
-        print("\nMOOOOCKED\n")
-        print(exception)
         raise exception
 
     monkeypatch.setattr(Dropbox, "files_list_folder", mock_api_exception)

--- a/app/tests/importers/test_dropbox.py
+++ b/app/tests/importers/test_dropbox.py
@@ -67,9 +67,7 @@ def dropbox_mock(monkeypatch: Any, remote_data: dict) -> None:
 
 @pytest.fixture
 def download_mock(monkeypatch: Any, basic_job: dict) -> None:
-    def mock_files_download_to_file(
-        self: Any, download_path: str, remote_path: str
-    ) -> None:
+    def mock_files_download_to_file(self: Any, download_path: str, path: str) -> None:
         with open(download_path, "wb") as file_handle:
             file_handle.write(b"dummycontent")
 
@@ -119,6 +117,7 @@ def download_mock(monkeypatch: Any, basic_job: dict) -> None:
                         rev="123456789",
                     ),
                     "children": {},
+                    "path": "root-folder/README.md",
                 },
                 "Subfolder": {
                     "entry": FolderMetadata(id="subfolder-1", name="Subfolder"),
@@ -133,8 +132,10 @@ def download_mock(monkeypatch: Any, basic_job: dict) -> None:
                                 rev="123456789",
                             ),
                             "children": {},
+                            "path": "subfolder-1/test.txt",
                         }
                     },
+                    "path": "root-folder/Subfolder",
                 },
             },
         )
@@ -149,7 +150,6 @@ def test_build_tree_recursively(
     importer.dropbox_handler = Dropbox(oauth2_access_token="sadas")
     tree: Dict = {}
     importer.build_tree_recursively(tree, "root-folder")
-
     assert tree == expected_tree
 
 
@@ -220,13 +220,17 @@ def test_dropbox_importer_success(
     assert job.status is JobStatus.IMPORTING_SUCCESSFULLY
 
 
+"""
 @pytest.fixture
 def launch_api_error(monkeypatch: Any, exception: Exception) -> None:
     def mock_api_exception(*args: List, **kwargs: Dict) -> None:
+        print("\nMOOOOCKED\n")
+        print(exception)
         raise exception
 
     monkeypatch.setattr(Dropbox, "files_list_folder", mock_api_exception)
-    monkeypatch.setattr(dropbox, "Dropbox", mock_api_exception)
+    monkeypatch.setattr(Dropbox, "files_download_to_file", mock_api_exception)
+    monkeypatch.setattr(dropbox, "Dropbox", mock_api_exception)"""
 
 
 @pytest.mark.parametrize(
@@ -247,10 +251,19 @@ def launch_api_error(monkeypatch: Any, exception: Exception) -> None:
         ),
     ],
 )
-@pytest.mark.usefixtures("launch_api_error")
 def test_dropbox_importer_api_error(
-    db: Session, basic_job: dict, exception: Exception, job_status: JobStatus
+    monkeypatch: Any,
+    db: Session,
+    basic_job: dict,
+    exception: Exception,
+    job_status: JobStatus,
 ) -> None:
+    def mock_api_exception(*args: List, **kwargs: Dict) -> None:
+        raise exception
+
+    monkeypatch.setattr(Dropbox, "files_list_folder", mock_api_exception)
+    monkeypatch.setattr(dropbox, "Dropbox", mock_api_exception)
+
     job = basic_job["db_job"]
     importer = DropboxImporter(db, job.id)
     importer.process()


### PR DESCRIPTION
The main change is that now we cannot use the files_download_to_file method. Instead of that, we need to use the sharing_get_shared_link